### PR TITLE
fix:using /usr/bin/env for bash

### DIFF
--- a/tools/bazel
+++ b/tools/bazel
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Linux distributions like NixOS do not have a `/bin/bash`, but always have a `/usr/bin/env`. So use /usr/bin/env to find `bash`

