### PR TITLE
Fixed 404 link to the explore.py file

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 This folder contains examples for how to use this library
 
-- [explore.py](./explore.py) is a quick script that give a quick overview how to use the C++ binding in Python.
+- [explore.py](./bindings/explore.py) is a quick script that give a quick overview how to use the C++ binding in Python.
 - [bentoml](./bentoml) contains a [BentoML](https://docs.bentoml.org/en/latest/) example for how to package whisper.cpp with this binding into a BentoML Service for production deployment.
 
 ### TODO


### PR DESCRIPTION
This fixes a 404 link to the explore.py file in the examples README.