### PR TITLE
fix: compatibility with GCC <10

### DIFF
--- a/src/whispercpp/context.cc
+++ b/src/whispercpp/context.cc
@@ -7,11 +7,10 @@
 #include <pybind11/pytypes.h>
 #endif
 
-
 #if __GNUC__ > 10 || defined(__clang__)
-#define STREAM_CAST 
+#define STREAM_CAST
 #else
-#define STREAM_CAST static_cast< std::stringstream & >
+#define STREAM_CAST static_cast<std::stringstream &>
 #endif
 
 #define NO_STATE_WARNING(no_state)                                             \
@@ -28,24 +27,22 @@
 #define RAISE_RUNTIME_ERROR(msg)                                               \
     do {                                                                       \
         throw std::runtime_error((std::stringstream()                          \
-                            << __FILE__ << "#L"                                \
-                            << std::to_string(__LINE__) << ": " << msg         \
-                            << "\n")                                           \
-                                .str());                                       \
+                                  << __FILE__ << "#L"                          \
+                                  << std::to_string(__LINE__) << ": " << msg   \
+                                  << "\n")                                     \
+                                     .str());                                  \
     } while (0)
 #else
 #define RAISE_RUNTIME_ERROR(msg)                                               \
     do {                                                                       \
         throw std::runtime_error(                                              \
-            static_cast< std::stringstream & > (std::stringstream()            \
-                            << __FILE__ << "#L"                                \
-                            << std::to_string(__LINE__) << ": " << msg         \
-                            << "\n")                                           \
-                                .str());                                       \
+            static_cast<std::stringstream &>(std::stringstream()               \
+                                             << __FILE__ << "#L"               \
+                                             << std::to_string(__LINE__)       \
+                                             << ": " << msg << "\n")           \
+                .str());                                                       \
     } while (0)
 #endif
-
-
 
 #define RAISE_IF_NULL(ptr)                                                     \
     do {                                                                       \
@@ -278,14 +275,14 @@ std::vector<float> Context::lang_detect(size_t offset_ms, size_t threads) {
     }
 
     if (res == -1) {
-        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
-                             << "offset " << offset_ms
-                             << "ms is before the start of audio.")
+        RAISE_RUNTIME_ERROR(STREAM_CAST(std::stringstream()
+                                        << "offset " << offset_ms
+                                        << "ms is before the start of audio.")
                                 .str());
     } else if (res == -2) {
-        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
-                             << "offset " << offset_ms
-                             << "ms is past the end of the audio.")
+        RAISE_RUNTIME_ERROR(STREAM_CAST(std::stringstream()
+                                        << "offset " << offset_ms
+                                        << "ms is past the end of the audio.")
                                 .str());
     } else if (res == -6) {
         RAISE_RUNTIME_ERROR("Failed to encode.");
@@ -393,11 +390,12 @@ int Context::full(Params params, std::vector<float> data) {
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
-                             << "audio_ctx is larger than maximum allowed ("
-                             << std::to_string(params.get()->audio_ctx) << " > "
-                             << this->n_audio_ctx() << ").")
-                                .str());
+        RAISE_RUNTIME_ERROR(
+            STREAM_CAST(std::stringstream()
+                        << "audio_ctx is larger than maximum allowed ("
+                        << std::to_string(params.get()->audio_ctx) << " > "
+                        << this->n_audio_ctx() << ").")
+                .str());
     } else if (ret == -6) {
         RAISE_RUNTIME_ERROR("Failed to encode.");
     } else if (ret == -7 || ret == -8) {
@@ -439,11 +437,12 @@ int Context::full_parallel(Params params, std::vector<float> data,
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
-                             << "audio_ctx is larger than maximum allowed ("
-                             << std::to_string(params.get()->audio_ctx) << " > "
-                             << this->n_audio_ctx() << ").")
-                                .str());
+        RAISE_RUNTIME_ERROR(
+            STREAM_CAST(std::stringstream()
+                        << "audio_ctx is larger than maximum allowed ("
+                        << std::to_string(params.get()->audio_ctx) << " > "
+                        << this->n_audio_ctx() << ").")
+                .str());
     } else if (ret == -6) {
         RAISE_RUNTIME_ERROR("Failed to encode.");
     } else if (ret == -7 || ret == -8) {

--- a/src/whispercpp/context.cc
+++ b/src/whispercpp/context.cc
@@ -19,7 +19,8 @@
 
 #define RAISE_RUNTIME_ERROR(msg)                                               \
     do {                                                                       \
-        throw std::runtime_error((std::stringstream()                          \
+        throw std::runtime_error(static_cast< std::stringstream & >            \
+                                  (std::stringstream()                         \
                                   << __FILE__ << "#L"                          \
                                   << std::to_string(__LINE__) << ": " << msg   \
                                   << "\n")                                     \
@@ -257,12 +258,12 @@ std::vector<float> Context::lang_detect(size_t offset_ms, size_t threads) {
     }
 
     if (res == -1) {
-        RAISE_RUNTIME_ERROR((std::stringstream()
+        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
                              << "offset " << offset_ms
                              << "ms is before the start of audio.")
                                 .str());
     } else if (res == -2) {
-        RAISE_RUNTIME_ERROR((std::stringstream()
+        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
                              << "offset " << offset_ms
                              << "ms is past the end of the audio.")
                                 .str());
@@ -372,7 +373,7 @@ int Context::full(Params params, std::vector<float> data) {
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR((std::stringstream()
+        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
                              << "audio_ctx is larger than maximum allowed ("
                              << std::to_string(params.get()->audio_ctx) << " > "
                              << this->n_audio_ctx() << ").")
@@ -418,7 +419,7 @@ int Context::full_parallel(Params params, std::vector<float> data,
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR((std::stringstream()
+        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
                              << "audio_ctx is larger than maximum allowed ("
                              << std::to_string(params.get()->audio_ctx) << " > "
                              << this->n_audio_ctx() << ").")

--- a/src/whispercpp/context.cc
+++ b/src/whispercpp/context.cc
@@ -7,10 +7,11 @@
 #include <pybind11/pytypes.h>
 #endif
 
-#ifndef __clang__
-    #define GCC_STRINGSTREAM_CAST static_cast< std::stringstream & >
-#elif __GNUC__
-    #define GCC_STRINGSTREAM_CAST ""
+
+#if __GNUC__ > 10 || defined(__clang__)
+#define STREAM_CAST 
+#else
+#define STREAM_CAST static_cast< std::stringstream & >
 #endif
 
 #define NO_STATE_WARNING(no_state)                                             \
@@ -23,15 +24,28 @@
         }                                                                      \
     } while (0)
 
+#if __GNUC__ > 10 || defined(__clang__)
 #define RAISE_RUNTIME_ERROR(msg)                                               \
     do {                                                                       \
-        throw std::runtime_error(GCC_STRINGSTREAM_CAST            \
-                                  (std::stringstream()                         \
-                                  << __FILE__ << "#L"                          \
-                                  << std::to_string(__LINE__) << ": " << msg   \
-                                  << "\n")                                     \
-                                     .str());                                  \
+        throw std::runtime_error((std::stringstream()                          \
+                            << __FILE__ << "#L"                                \
+                            << std::to_string(__LINE__) << ": " << msg         \
+                            << "\n")                                           \
+                                .str());                                       \
     } while (0)
+#else
+#define RAISE_RUNTIME_ERROR(msg)                                               \
+    do {                                                                       \
+        throw std::runtime_error(                                              \
+            static_cast< std::stringstream & > (std::stringstream()            \
+                            << __FILE__ << "#L"                                \
+                            << std::to_string(__LINE__) << ": " << msg         \
+                            << "\n")                                           \
+                                .str());                                       \
+    } while (0)
+#endif
+
+
 
 #define RAISE_IF_NULL(ptr)                                                     \
     do {                                                                       \
@@ -264,12 +278,12 @@ std::vector<float> Context::lang_detect(size_t offset_ms, size_t threads) {
     }
 
     if (res == -1) {
-        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
+        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
                              << "offset " << offset_ms
                              << "ms is before the start of audio.")
                                 .str());
     } else if (res == -2) {
-        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
+        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
                              << "offset " << offset_ms
                              << "ms is past the end of the audio.")
                                 .str());
@@ -379,7 +393,7 @@ int Context::full(Params params, std::vector<float> data) {
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
+        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
                              << "audio_ctx is larger than maximum allowed ("
                              << std::to_string(params.get()->audio_ctx) << " > "
                              << this->n_audio_ctx() << ").")
@@ -425,7 +439,7 @@ int Context::full_parallel(Params params, std::vector<float> data,
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
+        RAISE_RUNTIME_ERROR(STREAM_CAST (std::stringstream()
                              << "audio_ctx is larger than maximum allowed ("
                              << std::to_string(params.get()->audio_ctx) << " > "
                              << this->n_audio_ctx() << ").")

--- a/src/whispercpp/context.cc
+++ b/src/whispercpp/context.cc
@@ -7,6 +7,12 @@
 #include <pybind11/pytypes.h>
 #endif
 
+#ifndef __clang__
+    #define GCC_STRINGSTREAM_CAST static_cast< std::stringstream & >
+#elif __GNUC__
+    #define GCC_STRINGSTREAM_CAST ""
+#endif
+
 #define NO_STATE_WARNING(no_state)                                             \
     do {                                                                       \
         if (no_state) {                                                        \
@@ -19,7 +25,7 @@
 
 #define RAISE_RUNTIME_ERROR(msg)                                               \
     do {                                                                       \
-        throw std::runtime_error(static_cast< std::stringstream & >            \
+        throw std::runtime_error(GCC_STRINGSTREAM_CAST            \
                                   (std::stringstream()                         \
                                   << __FILE__ << "#L"                          \
                                   << std::to_string(__LINE__) << ": " << msg   \
@@ -258,12 +264,12 @@ std::vector<float> Context::lang_detect(size_t offset_ms, size_t threads) {
     }
 
     if (res == -1) {
-        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
+        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
                              << "offset " << offset_ms
                              << "ms is before the start of audio.")
                                 .str());
     } else if (res == -2) {
-        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
+        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
                              << "offset " << offset_ms
                              << "ms is past the end of the audio.")
                                 .str());
@@ -373,7 +379,7 @@ int Context::full(Params params, std::vector<float> data) {
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
+        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
                              << "audio_ctx is larger than maximum allowed ("
                              << std::to_string(params.get()->audio_ctx) << " > "
                              << this->n_audio_ctx() << ").")
@@ -419,7 +425,7 @@ int Context::full_parallel(Params params, std::vector<float> data,
     } else if (ret == -3) {
         RAISE_RUNTIME_ERROR("Failed to auto-detect language.");
     } else if (ret == -5) {
-        RAISE_RUNTIME_ERROR(static_cast< std::stringstream & > (std::stringstream()
+        RAISE_RUNTIME_ERROR(GCC_STRINGSTREAM_CAST (std::stringstream()
                              << "audio_ctx is larger than maximum allowed ("
                              << std::to_string(params.get()->audio_ctx) << " > "
                              << this->n_audio_ctx() << ").")


### PR DESCRIPTION
## What does this PR address?

this pr fix the compile error when compile on debian 11, gcc version 10.2.1 with bazel.
the error is:
`src/whispercpp/context.cc:26:39: error: 'class std::basic_ostream<char>' has no member named 'str'`

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [ x ] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [ x ] Did you read through and follow [development guidelines](../DEVELOPMENT.md)?
- [  ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [  ] Did you write tests to cover your changes?
