### PR TITLE
fix: remove lang_detect assertion

### DIFF
--- a/src/whispercpp/context.cc
+++ b/src/whispercpp/context.cc
@@ -289,7 +289,6 @@ std::vector<float> Context::lang_detect(size_t offset_ms, size_t threads) {
     } else if (res == -7) {
         RAISE_RUNTIME_ERROR("Failed to decode.");
     } else {
-        assert(res == (int)lang_probs.size());
         return lang_probs;
     }
 }


### PR DESCRIPTION
## What does this PR address?

Removes incorrect assertion that makes `Context::lang_detect` unusable.

## Before submitting:

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Did you read through and follow [development guidelines](../DEVELOPMENT.md)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes?
