### PR TITLE
fix: force `lib` to be output dir for sdl on multilib linux systems

### DIFF
--- a/extern/sdl2.BUILD
+++ b/extern/sdl2.BUILD
@@ -26,6 +26,7 @@ cmake(
         "CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
         "CMAKE_OSX_DEPLOYMENT_TARGET": "10.14",
         "CMAKE_POSITION_INDEPENDENT_CODE": "ON",
+        "CMAKE_INSTALL_LIBDIR": "lib",
         "SDL_SHARED": "OFF",
         "SDL_JOYSTICK": "OFF",
         "SDL_HAPTIC": "OFF",


### PR DESCRIPTION
## What does this PR address?

In some multilib linux systems cmake defaults to `lib64` as the install lib path. This forces it to the expected `lib`. Has no effect on non-multilib systems since this just sets the default to the default.

## Before submitting:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If you plan to update documentation or tests in follow-up, please note -->

- [x] Does the Pull Request follow [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#summary) naming? Here are [GitHub's
      guide](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) on how to create a pull request.
- [x] Did you read through and follow [development guidelines](../DEVELOPMENT.md)?
- [ ] Did your changes require updates to the documentation? Have you updated those accordingly?
- [ ] Did you write tests to cover your changes?
