### PR TITLE
Implement `logits_filter_callback`

### DIFF
--- a/src/whispercpp/api.pyi
+++ b/src/whispercpp/api.pyi
@@ -133,6 +133,9 @@ class Params:
     def on_progress(
         self, callback: t.Callable[[Context, int, T], None], userdata: T
     ) -> None: ...
+    def on_new_logits(
+        self, callback: t.Callable[[Context, int, NDArray[float], T], None], userdata: T
+    ) -> None: ...
 
 T = t.TypeVar("T")
 

--- a/tests/export_test.py
+++ b/tests/export_test.py
@@ -144,3 +144,21 @@ def test_progress_callback():
 
     m.transcribe(preprocess(ROOT / "samples" / "jfk.wav"))
     assert len(progresses) > 0
+
+
+def test_logits_callback():
+    def handleLogits(context: w.api.Context, n_tokens: int, logits: NDArray):
+        logits_data.append(n_tokens, logits)
+
+    m = w.Whisper.from_pretrained("tiny.en")
+
+    logits_data = []
+    m.params.on_new_logits(handleLogits, logits_data)
+
+    m.trasncripe(preprocess(ROOT / "samples" / "jfk.wav"))
+    assert len(logits_data) > 0
+
+    # make sure logits are passed by reference, so all logits stored
+    # should be equal to one another as none of them were copied in the
+    # callback and copies don't happen by default.
+    assert np.all(logits_data[0][1] == logits_data[1][1])


### PR DESCRIPTION
This is exposed via `on_new_logits` callback in the Python API to be consistent with the `on_new_...` scheme.

Note that currently only the number of tokens so far and the raw logits are exposed. So to be truly compatible with whisper.cpp the other arguments would need to be exposed to Python as well but it is better than nothing.

The logits are mutable so that the callback can indeed influence the decoding process. By using the `array_t` type this also safes us a copy.

I've added a test but I was not able to run the tests locally:

```plain
% ./tools/bazel test tests/...                                                                                                              (git)-[feature/logits-callback] 
INFO: Running bazel wrapper (see //tools/bazel for details), bazel version 6.0.0 will be used instead of system-wide bazel installation.
ERROR: .../pywhispercpp/tests/BUILD:26:8: no such package '@pypi_pytest_io//': The repository '@pypi_pytest_asyncio' could not be resolved: Repository '@pypi_pytest_asyncio' is not defined and referenced by '//tests:utils'
ERROR: Analysis of target '//tests:utils' failed; build aborted: Analysis failed
INFO: Elapsed time: 0.107s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
ERROR: Couldn't start the build. Unable to run tests
```